### PR TITLE
feat: add CodSpeed to the project

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,33 @@
+name: codspeed-benchmarks
+
+on:
+  # Run on pushes to the master branch
+  push:
+    branches:
+      - "master"
+  # Run on pull requests
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup rust toolchain, cache and cargo-codspeed binary
+        uses: moonrepo/setup-rust@v1
+        with:
+          cache-target: release
+          bins: cargo-codspeed
+
+      - name: Build the benchmark target(s)
+        working-directory: v3
+        run: cargo codspeed build -p engine -p lang-graphql
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v2
+        with:
+          working-directory: v3
+          run: cargo codspeed run -p engine -p lang-graphql

--- a/v3/Cargo.lock
+++ b/v3/Cargo.lock
@@ -909,10 +909,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "codspeed"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089"
+dependencies = [
+ "colored",
+ "libc",
+ "serde_json",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe"
+dependencies = [
+ "codspeed",
+ "colored",
+ "criterion",
+ "futures",
+ "tokio",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "combine"
@@ -1717,7 +1751,7 @@ dependencies = [
  "base64 0.22.1",
  "build-data",
  "clap",
- "criterion",
+ "codspeed-criterion-compat",
  "execute",
  "goldenfile",
  "hasura-authn-core",
@@ -1792,7 +1826,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "criterion",
+ "codspeed-criterion-compat",
  "derive_more",
  "futures-ext",
  "futures-util",
@@ -2594,7 +2628,7 @@ dependencies = [
  "axum",
  "bincode",
  "bson",
- "criterion",
+ "codspeed-criterion-compat",
  "diffy",
  "expect-test",
  "graphql-parser",

--- a/v3/Cargo.toml
+++ b/v3/Cargo.toml
@@ -70,7 +70,7 @@ bytes = "1"
 clap = "4"
 convert_case = "0.6"
 cookie = "0.18"
-criterion = "0.5"
+criterion = { package="codspeed-criterion-compat", version = "2.6.0" }
 darling = "0.20"
 derive_more = "0.99"
 diffy = "0.4"


### PR DESCRIPTION
## Variance tests

```text
Found 101 runs for CodSpeedHQ/graphql-engine (1eb16f5b9007b766a6e14752e3b1366ee0618f62)
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────┬───────────────────┬─────────────────────┬────────────┬──────────────────┐
│                                                          (index)                                                          │  average   │ standardDeviation │ varianceCoefficient │   range    │ rangeCoefficient │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────┼─────────────────────┼────────────┼──────────────────┤
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-postcard[100]           │  '3.3 ms'  │    '178.7 µs'     │       '5.5%'        │ '358.8 µs' │     '11.0%'      │
│   v3/crates/engine/benches/execute.rs::benches::bench_execute_all::relay_node_field::bench_execute[Generate Query Plan]   │ '37.8 µs'  │    '906.5 ns'     │       '2.4%'        │  '3.7 µs'  │      '9.9%'      │
│          v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-postcard[1000]           │ '31.5 ms'  │    '545.4 µs'     │       '1.7%'        │  '1.4 ms'  │      '4.5%'      │
│          v3/crates/engine/benches/generate_ir.rs::benches::bench_generate_ir::generate_ir::generate_ir[typename]          │ '15.1 µs'  │    '199.7 ns'     │       '1.3%'        │  '1.4 µs'  │      '9.1%'      │
│ v3/crates/engine/benches/execute.rs::benches::bench_execute_all::object_relationship::bench_execute[Generate Query Plan]  │ '60.6 µs'  │    '786.6 ns'     │       '1.3%'        │  '4.1 µs'  │      '6.8%'      │
│      v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many::bench[Resolution of raw request]       │ '30.3 µs'  │    '388.7 ns'     │       '1.3%'        │  '1.7 µs'  │      '5.5%'      │
│      v3/crates/engine/benches/execute.rs::benches::bench_execute_all::array_relationship::bench_execute[Generate IR]      │ '70.5 µs'  │    '856.3 ns'     │       '1.2%'        │  '3.8 µs'  │      '5.4%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::array_relationship::bench_execute[Generate Query Plan]  │ '65.8 µs'  │    '759.3 ns'     │       '1.2%'        │  '4.7 µs'  │      '7.2%'      │
│         v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many::bench_execute[Generate IR]          │ '49.6 µs'  │    '442.5 ns'     │       '0.9%'        │  '1.7 µs'  │      '3.5%'      │
│          v3/crates/engine/benches/generate_ir.rs::benches::bench_generate_ir::generate_ir::generate_ir[get_many]          │ '49.6 µs'  │     '398 ns'      │       '0.8%'        │   '2 µs'   │      '4.1%'      │
│    v3/crates/engine/benches/execute.rs::benches::bench_execute_all::relay_node_field::bench[Resolution of raw request]    │ '30.9 µs'  │    '207.9 ns'     │       '0.7%'        │ '906.1 ns' │      '2.9%'      │
│     v3/crates/engine/benches/execute.rs::benches::bench_execute_all::object_relationship::bench_execute[Generate IR]      │ '66.3 µs'  │    '442.5 ns'     │       '0.7%'        │  '2.4 µs'  │      '3.6%'      │
│     v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many::bench_execute[Generate Query Plan]      │ '42.7 µs'  │    '278.5 ns'     │       '0.7%'        │  '1.1 µs'  │      '2.6%'      │
│      v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many_where::bench_execute[Generate IR]       │ '202.5 µs' │     '1.2 µs'      │       '0.6%'        │  '6.7 µs'  │      '3.3%'      │
│      v3/crates/engine/benches/generate_ir.rs::benches::bench_generate_ir::generate_ir::generate_ir[get_many_user_2]       │ '42.6 µs'  │    '245.4 ns'     │       '0.6%'        │  '1.1 µs'  │      '2.7%'      │
│       v3/crates/engine/benches/execute.rs::benches::bench_execute_all::relay_node_field::bench_execute[Generate IR]       │  '50 µs'   │    '281.5 ns'     │       '0.6%'        │   '2 µs'   │      '4.0%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::object_relationship::bench[Resolution of raw request]   │ '40.1 µs'  │    '211.1 ns'     │       '0.5%'        │  '1.1 µs'  │      '2.6%'      │
│           v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::async-graphql[introspection]           │  '1.3 ms'  │      '6 µs'       │       '0.5%'        │ '60.6 µs'  │      '4.6%'      │
│   v3/crates/engine/benches/execute.rs::benches::bench_execute_all::array_relationship::bench[Resolution of raw request]   │  '41 µs'   │    '163.8 ns'     │       '0.4%'        │   '1 µs'   │      '2.5%'      │
│    v3/crates/engine/benches/generate_ir.rs::benches::bench_generate_ir::generate_ir::generate_ir[get_many_model_count]    │ '106.9 µs' │    '421.4 ns'     │       '0.4%'        │   '2 µs'   │      '1.8%'      │
│         v3/crates/engine/benches/generate_ir.rs::benches::bench_generate_ir::generate_ir::generate_ir[get_by_id]          │ '51.2 µs'  │    '197.3 ns'     │       '0.4%'        │  '1.1 µs'  │      '2.2%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::object_relationship::bench_execute[Execute Query Plan]  │ '829.8 µs' │     '3.2 µs'      │       '0.4%'        │  '20 µs'   │      '2.4%'      │
│   v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many_where::bench_execute[Execute Query Plan]   │  '2.8 ms'  │     '10.6 µs'     │       '0.4%'        │ '48.6 µs'  │      '1.7%'      │
│      v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many::bench_execute[Execute Query Plan]      │ '791.8 µs' │     '2.9 µs'      │       '0.4%'        │ '13.6 µs'  │      '1.7%'      │
│       v3/crates/engine/benches/generate_ir.rs::benches::bench_generate_ir::generate_ir::generate_ir[get_many_where]       │ '86.2 µs'  │    '316.2 ns'     │       '0.4%'        │  '1.9 µs'  │      '2.2%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many_where::bench_execute[Generate Query Plan]   │ '158.4 µs' │    '565.6 ns'     │       '0.4%'        │  '2.7 µs'  │      '1.7%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::array_relationship::bench_execute[Execute Query Plan]   │ '843.4 µs' │      '3 µs'       │       '0.4%'        │ '17.5 µs'  │      '2.1%'      │
│ v3/crates/engine/benches/execute.rs::benches::bench_execute_all::array_relationship::bench_execute[Total Execution time]  │  '1.2 ms'  │     '4.1 µs'      │       '0.3%'        │ '18.5 µs'  │      '1.6%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::relay_node_field::bench_execute[Total Execution time]   │  '1.1 ms'  │     '3.4 µs'      │       '0.3%'        │ '18.2 µs'  │      '1.7%'      │
│   v3/crates/engine/benches/execute.rs::benches::bench_execute_all::relay_node_field::bench_execute[Execute Query Plan]    │ '787.6 µs' │     '2.4 µs'      │       '0.3%'        │ '14.7 µs'  │      '1.9%'      │
│      v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many::bench_execute[Normalize request]       │  '92 µs'   │    '275.8 ns'     │       '0.3%'        │  '2.1 µs'  │      '2.2%'      │
│     v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many::bench_execute[Total Execution time]     │  '1.1 ms'  │     '3.2 µs'      │       '0.3%'        │ '14.1 µs'  │      '1.3%'      │
│ v3/crates/engine/benches/execute.rs::benches::bench_execute_all::object_relationship::bench_execute[Total Execution time] │  '1.2 ms'  │     '3.2 µs'      │       '0.3%'        │ '17.7 µs'  │      '1.5%'      │
│   v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many_where::bench_execute[Normalize request]    │ '396.8 µs' │      '1 µs'       │       '0.3%'        │  '7.4 µs'  │      '1.9%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many_where::bench_execute[Total Execution time]  │  '3.8 ms'  │     '9.3 µs'      │       '0.2%'        │ '48.5 µs'  │      '1.3%'      │
│                  v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::hasura[small]                   │ '20.7 µs'  │      '49 ns'      │       '0.2%'        │ '127.8 ns' │      '0.6%'      │
│   v3/crates/engine/benches/execute.rs::benches::bench_execute_all::select_many_where::bench[Resolution of raw request]    │ '187.7 µs' │    '397.4 ns'     │       '0.2%'        │  '2.6 µs'  │      '1.4%'      │
│    v3/crates/engine/benches/execute.rs::benches::bench_execute_all::simple_select::bench_execute[Total Execution time]    │  '1.1 ms'  │     '2.1 µs'      │       '0.2%'        │  '5.7 µs'  │      '0.5%'      │
│    v3/crates/engine/benches/execute.rs::benches::bench_execute_all::simple_select::bench_execute[Generate Query Plan]     │ '48.4 µs'  │     '78.1 ns'     │       '0.2%'        │ '222.2 ns' │      '0.5%'      │
│    v3/crates/engine/benches/execute.rs::benches::bench_execute_all::relay_node_field::bench_execute[Normalize request]    │ '76.6 µs'  │     '120 ns'      │       '0.2%'        │ '638.3 ns' │      '0.8%'      │
│                    v3/crates/lang-graphql/benches/lexer.rs::benches::bench_lexer::lexer::hasura[small]                    │ '10.3 µs'  │     '13.7 ns'     │       '0.1%'        │ '27.8 ns'  │      '0.3%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-postcard[100]            │ '19.2 ms'  │     '23.8 µs'     │       '0.1%'        │ '50.5 µs'  │      '0.3%'      │
│  v3/crates/engine/benches/execute.rs::benches::bench_execute_all::object_relationship::bench_execute[Normalize request]   │ '102.9 µs' │    '126.2 ns'     │       '0.1%'        │ '707.2 ns' │      '0.7%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-msgpack[100]            │ '32.8 ms'  │     '37.6 µs'     │       '0.1%'        │ '83.7 µs'  │      '0.3%'      │
│              v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::hasura[introspection]               │ '256.4 µs' │    '263.4 ns'     │       '0.1%'        │  '1.3 µs'  │      '0.5%'      │
│   v3/crates/engine/benches/execute.rs::benches::bench_execute_all::array_relationship::bench_execute[Normalize request]   │ '105.6 µs' │     '107 ns'      │       '0.1%'        │ '752.2 ns' │      '0.7%'      │
│     v3/crates/engine/benches/execute.rs::benches::bench_execute_all::simple_select::bench_execute[Normalize request]      │ '98.4 µs'  │     '97.1 ns'     │       '0.1%'        │ '546.1 ns' │      '0.6%'      │
│      v3/crates/lang-graphql/benches/validation.rs::benches::bench_validation::validation::hasura[IntrospectionQuery]      │  '1.8 ms'  │     '1.7 µs'      │       '0.1%'        │  '5.1 µs'  │      '0.3%'      │
│                  v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::apollo[large]                   │   '4 ms'   │     '3.8 µs'      │       '0.1%'        │ '48.5 µs'  │      '1.2%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-json[1000]             │ '202.3 ms' │    '190.1 µs'     │       '0.1%'        │ '585.8 µs' │      '0.3%'      │
│     v3/crates/engine/benches/execute.rs::benches::bench_execute_all::simple_select::bench_execute[Execute Query Plan]     │ '804.7 µs' │    '711.4 ns'     │       '0.1%'        │  '2.7 µs'  │      '0.3%'      │
│        v3/crates/engine/benches/execute.rs::benches::bench_execute_all::simple_select::bench_execute[Generate IR]         │ '55.7 µs'  │     '47.6 ns'     │       '0.1%'        │ '196.7 ns' │      '0.4%'      │
│               v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::async-graphql[large]               │  '5.8 ms'  │     '4.7 µs'      │       '0.1%'        │ '26.7 µs'  │      '0.5%'      │
│     v3/crates/engine/benches/execute.rs::benches::bench_execute_all::simple_select::bench[Resolution of raw request]      │ '36.2 µs'  │     '27.2 ns'     │       '0.1%'        │ '55.6 ns'  │      '0.2%'      │
│                  v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::hasura[large]                   │  '1.1 ms'  │    '740.7 ns'     │       '0.1%'        │  '4.6 µs'  │      '0.4%'      │
│              v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::apollo[introspection]               │ '846.9 µs' │    '534.8 ns'     │       '0.1%'        │  '2.3 µs'  │      '0.3%'      │
│          v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::graphql-parser[introspection]           │  '718 µs'  │    '370.9 ns'     │       '0.1%'        │  '2.9 µs'  │      '0.4%'      │
│          v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-postcard[10000]          │ '319.3 ms' │    '145.6 µs'     │       '0.0%'        │ '460.5 µs' │      '0.1%'      │
│                    v3/crates/lang-graphql/benches/lexer.rs::benches::bench_lexer::lexer::apollo[small]                    │ '16.5 µs'  │     '4.7 ns'      │       '0.0%'        │ '27.8 ns'  │      '0.2%'      │
│          v3/crates/lang-graphql/benches/validation.rs::benches::bench_validation::validation::hasura[RootFields]          │ '737.9 µs' │    '194.5 ns'     │       '0.0%'        │  '1.1 µs'  │      '0.1%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-bson[1000]             │ '178.5 ms' │     '42.9 µs'     │       '0.0%'        │ '170.9 µs' │      '0.1%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-bincode[10000]           │  '1.9 s'   │    '459.8 µs'     │       '0.0%'        │  '1.9 ms'  │      '0.1%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-bincode[1000]            │ '187.4 ms' │     '44.6 µs'     │       '0.0%'        │ '207.9 µs' │      '0.1%'      │
│          v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-msgpack[10000]           │  '645 ms'  │    '150.3 µs'     │       '0.0%'        │ '471.4 µs' │      '0.1%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-bincode[100]            │ '18.9 ms'  │     '4.3 µs'      │       '0.0%'        │ '12.3 µs'  │      '0.1%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-bincode[1000]           │ '40.1 ms'  │     '9.1 µs'      │       '0.0%'        │ '45.9 µs'  │      '0.1%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-json[10000]             │  '4.1 s'   │    '796.1 µs'     │       '0.0%'        │  '1.8 ms'  │      '0.0%'      │
│             v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-json[1000]             │ '405.1 ms' │     '72.7 µs'     │       '0.0%'        │ '269.3 µs' │      '0.1%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-postcard[1000]           │ '189.9 ms' │     '31.8 µs'     │       '0.0%'        │ '128.8 µs' │      '0.1%'      │
│               v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::async-graphql[small]               │ '94.7 µs'  │     '15.5 ns'     │       '0.0%'        │ '83.3 ns'  │      '0.1%'      │
│                v3/crates/lang-graphql/benches/lexer.rs::benches::bench_lexer::lexer::hasura[introspection]                │  '111 µs'  │     '13.7 ns'     │       '0.0%'        │ '27.8 ns'  │      '0.0%'      │
│             v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-json[100]              │ '41.4 ms'  │      '5 µs'       │       '0.0%'        │ '11.1 µs'  │      '0.0%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-bson[10000]            │  '1.7 s'   │    '207.1 µs'     │       '0.0%'        │  '750 µs'  │      '0.0%'      │
│          v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-postcard[10000]           │  '1.9 s'   │    '220.4 µs'     │       '0.0%'        │  '1.3 ms'  │      '0.1%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-msgpack[10000]           │  '3.3 s'   │     '329 µs'      │       '0.0%'        │  '1.1 ms'  │      '0.0%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-msgpack[1000]            │ '322.1 ms' │      '32 µs'      │       '0.0%'        │ '142.7 µs' │      '0.0%'      │
│              v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::graphql-parser[small]               │ '84.1 µs'  │     '8.3 ns'      │       '0.0%'        │ '83.3 ns'  │      '0.1%'      │
│             v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-bson[1000]             │ '623.9 ms' │     '56.1 µs'     │       '0.0%'        │  '237 µs'  │      '0.0%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-bson[10000]             │  '6.3 s'   │    '467.2 µs'     │       '0.0%'        │  '1.5 ms'  │      '0.0%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-bincode[100]            │  '4.1 ms'  │    '234.3 ns'     │       '0.0%'        │  '1.4 µs'  │      '0.0%'      │
│                    v3/crates/lang-graphql/benches/lexer.rs::benches::bench_lexer::lexer::hasura[large]                    │ '504.4 µs' │     '26.8 ns'     │       '0.0%'        │ '55.6 ns'  │      '0.0%'      │
│             v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::de-bson[100]              │ '63.8 ms'  │     '2.7 µs'      │       '0.0%'        │  '7.8 µs'  │      '0.0%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-msgpack[100]            │  '6.5 ms'  │    '217.3 ns'     │       '0.0%'        │  '1.3 µs'  │      '0.0%'      │
│                v3/crates/lang-graphql/benches/lexer.rs::benches::bench_lexer::lexer::apollo[introspection]                │  '221 µs'  │     '4.7 ns'      │       '0.0%'        │ '27.8 ns'  │      '0.0%'      │
│            v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-json[10000]            │  '1.9 s'   │     '24.6 µs'     │       '0.0%'        │  '147 µs'  │      '0.0%'      │
│           v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-msgpack[1000]           │ '62.5 ms'  │    '769.6 ns'     │       '0.0%'        │  '3.7 µs'  │      '0.0%'      │
│             v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-json[100]             │ '19.8 ms'  │    '217.8 ns'     │       '0.0%'        │  '1.3 µs'  │      '0.0%'      │
│          v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-bincode[10000]           │  '421 ms'  │     '4.5 µs'      │       '0.0%'        │ '29.4 µs'  │      '0.0%'      │
│             v3/crates/lang-graphql/benches/schema_serde.rs::benches::bench_serde::schema_serde::ser-bson[100]             │ '19.3 ms'  │    '203.4 ns'     │       '0.0%'        │  '1.1 µs'  │      '0.0%'      │
│              v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::graphql-parser[large]               │  '4.1 ms'  │      '27 ns'      │       '0.0%'        │ '55.6 ns'  │      '0.0%'      │
│                    v3/crates/lang-graphql/benches/lexer.rs::benches::bench_lexer::lexer::apollo[large]                    │ '990.8 µs' │     '4.7 ns'      │       '0.0%'        │ '27.8 ns'  │      '0.0%'      │
│                  v3/crates/lang-graphql/benches/parser.rs::benches::bench_parser::parser::apollo[small]                   │ '67.6 µs'  │      '0 ns'       │       '0.0%'        │   '0 s'    │      '0.0%'      │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────┴───────────────────┴─────────────────────┴────────────┴──────────────────┘
```

Bulk of the benchmarks are stable, one or two outlier